### PR TITLE
Add command line arguments

### DIFF
--- a/dbapi.py
+++ b/dbapi.py
@@ -99,7 +99,7 @@ def import_prices_api(db_cursor, prices):
                 (price["SiteId"], price["FuelId"]))
             row = db_cursor.fetchone()
 
-            if row[2] != parse_datetime(price["TransactionDateUtc"]) and row[1] != price["Price"]:
+            if db_cursor.rowcount == 0 or (row[2] != parse_datetime(price["TransactionDateUtc"]) and row[1] != price["Price"]):
                 if price["Price"] > 9999:
                     #assume prices above 9999 are not correct
                     active = "False"

--- a/dbapi.py
+++ b/dbapi.py
@@ -15,7 +15,7 @@ def import_regions(db_cursor, regions):
             
             region["GeoRegionParentId"] = query_return[0]
 
-        db_cursor.execute("INSERT INTO region (name, original_id, geographical_level, abbrevation, region_parent_id, active) VALUES (%s, %s, %s, %s, %s, TRUE)",
+        db_cursor.execute("INSERT INTO region (name, original_id, geographical_level, abbreviation, region_parent_id, active) VALUES (%s, %s, %s, %s, %s, TRUE)",
             (region["Name"], region["GeoRegionId"], region["GeoRegionLevel"], region["Abbrev"], region["GeoRegionParentId"]))
 
 def import_brands(db_cursor, brands):

--- a/dbapi.py
+++ b/dbapi.py
@@ -19,20 +19,25 @@ def import_regions(db_cursor, regions):
 
 def import_brands(db_cursor, brands):
     for brand in brands:
-        db_cursor.execute("INSERT INTO brand (id, name, active) VALUES (%s, %s, TRUE)",
-            (brand["BrandId"], brand["Name"]))
+        db_cursor.execute("""INSERT INTO brand (id, name, active) VALUES (%s, %s, TRUE)
+            ON CONFLICT(id) DO UPDATE SET name = %s""",
+            (brand["BrandId"], brand["Name"], brand["Name"]))
 
 def import_fuels(db_cursor, fuels):
     for fuel in fuels:
-        db_cursor.execute("INSERT INTO fuel (id, name, active) VALUES (%s, %s, TRUE)",
-            (fuel["FuelId"], fuel["Name"]))
+        db_cursor.execute("""INSERT INTO fuel (id, name, active) VALUES (%s, %s, TRUE)
+            ON CONFLICT(id) DO UPDATE SET name = %s""",
+            (fuel["FuelId"], fuel["Name"], fuel["Name"]))
 
 def import_sites(db_cursor, sites):
     db_cursor.execute("SET timezone = 'utc';")
     db_cursor.execute("SET datestyle = dmy;")
     for site in sites:
-        db_cursor.execute("INSERT INTO site (id, name, brand_id, address, post_code, latitude, longitude, modified_date, active) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, TRUE)",
-            (site["S"], site["N"], site["B"], site["A"], site["P"], site["Lat"], site["Lng"], site["M"]))
+        db_cursor.execute("""INSERT INTO site (id, name, brand_id, address, post_code, latitude, longitude, modified_date, active) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, TRUE)
+            ON CONFLICT(id) DO UPDATE SET name = %s, brand_id = %s, address = %s, post_code = %s, latitude = %s, longitude = %s, modified_date = %s""",
+            (site["S"], site["N"], site["B"], site["A"], site["P"], site["Lat"], site["Lng"], site["M"],
+            site["N"], site["B"], site["A"], site["P"], site["Lat"], site["Lng"], site["M"]))
 
 def generate_site_region(db_cursor, sites):
     region_fields = ["G1", "G2", "G3", "G4", "G5"]

--- a/dbapi.py
+++ b/dbapi.py
@@ -1,6 +1,7 @@
 import psycopg2
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 def import_regions(db_cursor, regions):
     #region list is reversed to prevent same table foreign key error
@@ -68,38 +69,51 @@ def generate_site_fuel(db_conn, sites):
             db_cursor2.execute("INSERT INTO site_fuel (site_id, fuel_id, active) VALUES (%s, %s, TRUE)",
                 (site["S"], fuel_id))
 
-def import_prices_api(db_cursor, prices, limit_minutes):
+def parse_datetime(datetime_string):
+    #need to make strings the same format before parsing
+    if len(datetime_string) == 19:
+        datetime_string = "".join((datetime_string, "."))
+    datetime_string = datetime_string.ljust(26, '0')
+
+    parsed_date = datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%S.%f")
+    parsed_date = parsed_date.replace(tzinfo= timezone.utc)
+    return parsed_date
+
+def import_prices_api(db_cursor, prices):
     db_cursor.execute("SET timezone = 'utc';")
     db_cursor.execute("SET datestyle = dmy;")
 
-    interval = timedelta(minutes=limit_minutes)
-
     new_prices_counter = 0
     unavailable_fuels_counter = 0
+
     for price in prices:
-        price_time = datetime.strptime(price["TransactionDateUtc"][:19], "%Y-%m-%dT%H:%M:%S")
-        if(datetime.utcnow() - price_time < interval):
-            new_prices_counter += 1
-            if price["Price"] == 9999:
-                #9999 is apparently used to denote the fuel is unavailable
-                #Will not be added to the 'price' table for now
-                unavailable_fuels_counter += 1
-                db_cursor.execute("UPDATE site_fuel SET active = False WHERE site_id = %s AND fuel_id = %s",
-                    (price["SiteId"], price["FuelId"]))
-            else:
-                active = "True"
+        if price["Price"] == 9999:
+            #9999 is apparently used to denote the fuel is unavailable
+            #Will not be added to the 'price' table for now
+            db_cursor.execute("UPDATE site_fuel SET active = False WHERE site_id = %s AND fuel_id = %s",
+                (price["SiteId"], price["FuelId"]))
+            unavailable_fuels_counter += 1
+        else:
+            #grab last row of matching site_id and fuel_id for comparison
+            db_cursor.execute("SELECT id, amount, transaction_date FROM price WHERE site_id = %s AND fuel_id = %s ORDER BY transaction_date DESC LIMIT 1",
+                (price["SiteId"], price["FuelId"]))
+            row = db_cursor.fetchone()
+
+            if row[2] != parse_datetime(price["TransactionDateUtc"]) and row[1] != price["Price"]:
                 if price["Price"] > 9999:
                     #assume prices above 9999 are not correct
                     active = "False"
+                else:
+                    active = "True"
                 db_cursor.execute("""INSERT INTO price (site_id, fuel_id, collection_method, amount, transaction_date, active) VALUES (%s, %s, %s, %s, %s, %s)
                     ON CONFLICT DO NOTHING""",
-                (price["SiteId"], price["FuelId"], price["CollectionMethod"], price["Price"], price["TransactionDateUtc"], active))
+                    (price["SiteId"], price["FuelId"], price["CollectionMethod"], price["Price"], price["TransactionDateUtc"], active))
+                new_prices_counter += 1
+            
+            #assume fuel is active again if the price isn't 9999
+            db_cursor.execute("UPDATE site_fuel SET active = True WHERE site_id = %s AND fuel_id = %s",
+                (price["SiteId"], price["FuelId"]))
 
-                #assume fuel is active again if there's a new price
-                db_cursor.execute("UPDATE site_fuel SET active = True WHERE site_id = %s AND fuel_id = %s",
-                    (price["SiteId"], price["FuelId"]))
-
-    
     print("Prices inserted from api: {}".format(new_prices_counter))
     print("Unavailable fuels: {}".format(unavailable_fuels_counter))
 

--- a/dbapi.py
+++ b/dbapi.py
@@ -15,8 +15,13 @@ def import_regions(db_cursor, regions):
             
             region["GeoRegionParentId"] = query_return[0]
 
-        db_cursor.execute("INSERT INTO region (name, original_id, geographical_level, abbreviation, region_parent_id, active) VALUES (%s, %s, %s, %s, %s, TRUE)",
-            (region["Name"], region["GeoRegionId"], region["GeoRegionLevel"], region["Abbrev"], region["GeoRegionParentId"]))
+        db_cursor.execute("UPDATE region SET name = %s, abbreviation = %s WHERE original_id = %s AND geographical_level = %s", 
+            (region["Name"], region["Abbrev"], region["GeoRegionId"], region["GeoRegionLevel"]))
+        
+        if db_cursor.rowcount == 0:
+            #if nothing was updated in the previous query insert instead
+            db_cursor.execute("INSERT INTO region (name, original_id, geographical_level, abbreviation, region_parent_id, active) VALUES (%s, %s, %s, %s, %s, TRUE)",
+                (region["Name"], region["GeoRegionId"], region["GeoRegionLevel"], region["Abbrev"], region["GeoRegionParentId"]))
 
 def import_brands(db_cursor, brands):
     for brand in brands:

--- a/qldfuel-dl.py
+++ b/qldfuel-dl.py
@@ -141,6 +141,9 @@ dbapi.import_prices_csv(db_cursor, "qldfuelprices.csv")
 
 dbapi.generate_site_fuel(db_conn, sites)
 
+prices = api_conn.get_prices()
+dbapi.import_prices_api(db_cursor, prices, 20)
+
 db_cursor.close()
 db_conn.close()
 print("Import done")

--- a/qldfuel-dl.py
+++ b/qldfuel-dl.py
@@ -142,7 +142,7 @@ dbapi.import_prices_csv(db_cursor, "qldfuelprices.csv")
 dbapi.generate_site_fuel(db_conn, sites)
 
 prices = api_conn.get_prices()
-dbapi.import_prices_api(db_cursor, prices, 20)
+dbapi.import_prices_api(db_cursor, prices)
 
 db_cursor.close()
 db_conn.close()

--- a/setuptables.sql
+++ b/setuptables.sql
@@ -4,7 +4,7 @@ CREATE TABLE public.region
     name character varying,
     original_id integer,
     geographical_level integer,
-    abbrevation character varying,
+    abbreviation character varying,
     region_parent_id integer,
 	active boolean,
     PRIMARY KEY (id),


### PR DESCRIPTION
Main data (price/sites/brands/fuels) can now be updated from the official API.
Prices from the official API can be added to the database without duplicates or excessively using up IDs (serial column).